### PR TITLE
Changes type for `s, --suffix` option from `number` to `string`

### DIFF
--- a/bin/sakugawa.js
+++ b/bin/sakugawa.js
@@ -46,7 +46,7 @@ const cmdOptions = {
   s: {
     description: 'Output CSS file suffix',
     alias: 'suffix',
-    type: 'number',
+    type: 'string',
     default: '_'
   },
   M: {


### PR DESCRIPTION
closes #40